### PR TITLE
go.mod: fix module path

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
-module github.com/rfc5424
+module github.com/crewjam/rfc5424
 
 go 1.13
 
 require (
-	github.com/crewjam/rfc5424 v0.0.0-20180723152949-c25bdd3a0ba2
-	github.com/dvyukov/go-fuzz v0.0.0-20191206100749-a378175e205c // indirect
+	github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e // indirect
+	gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,7 @@
-github.com/crewjam/rfc5424 v0.0.0-20180723152949-c25bdd3a0ba2 h1:ikTypaS8gho3dBf1gySXxxv+NkB8vyYgqMPYv51LD4U=
-github.com/crewjam/rfc5424 v0.0.0-20180723152949-c25bdd3a0ba2/go.mod h1:+E6hJ4dnJi+OtRGvE3sIOIwMivXJTbRqZfQkWeANo6I=
-github.com/dvyukov/go-fuzz v0.0.0-20191206100749-a378175e205c h1:/bXaeEuNG6V0HeyEGw11DYLW5BGsOPlcVRIXbHNUWSo=
-github.com/dvyukov/go-fuzz v0.0.0-20191206100749-a378175e205c/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
+github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
+github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
+github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
+github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f h1:BLraFXnmrev5lT+xlilqcH8XK9/i0At2xKjWk4p6zsU=
+gopkg.in/check.v1 v1.0.0-20200227125254-8fa46927fb4f/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
#6 added a go.mod file but the module path was `github.com/rfc5424` instead of `github.com/crewjam/rfc5424`. This can lead to confusion/errors when trying to use this module.

If this is merged, it would be nice to tag an initial v0 version, such as v0.1.0, so users can easily pick it up. More info can be found [in this blog post](https://blog.golang.org/publishing-go-modules).